### PR TITLE
adds capabilities registry

### DIFF
--- a/veps/sig-compute/hypervisor-abstraction.md
+++ b/veps/sig-compute/hypervisor-abstraction.md
@@ -65,10 +65,12 @@ Cluster configuration (`spec.configuration.hypervisorConfiguration.name`) declar
    }
    ```
    Only zero-value fields are set at each layer; `FinalizeVMI` handles derived/status data (CPU topology snapshot, memory status, hotplug sizing, feature dependency resolution). Existing public functions delegate to the resolved provider for backwards compatibility.
+
+- **Capability registry (`pkg/capabilities/`)** – Provides a centralized, declarative model for expressing which features are supported, unsupported, or experimental on each hypervisor+architecture combination. The registry enables automatic validation, test filtering, and clear error messages without duplicating logic across components. Each hypervisor declares its capabilities once (e.g., `pkg/capabilities/hypervisor/kvm/amd64.go`) and all validation/testing consumes these declarations.
 - **Runtime interface (`pkg/hypervisor/runtime/`)** – Provides a shared `HypervisorRuntime` contract for runtime-specific behavior such as `AdjustResources`, `HandleHousekeeping`, and `GetMemoryOverhead`. Each implementation registers under the same hypervisor key so `virt-controller`, `virt-handler`, and virt-launcher can resolve the correct runtime hooks.
 - **Converter library (`pkg/virt-launcher/virtwrap/converter/hypervisor/`)** – Implements the new `HypervisorConverter` interface described below. Each hypervisor file focuses on XML/domain differences while `base.go` holds the shared helpers. The converter selects the correct implementation via a local registry keyed by hypervisor name.
-- **Admission webhooks (`pkg/virt-api/webhooks/validating-webhook/admitters/hypervisor/`)** – Surface validation and mutation helpers that wrap existing webhook entry points. The admitters use the same cluster-configured hypervisor value as `virt-controller` and invoke the matching implementation.
-- **Node labeller (`pkg/virt-handler/node-labeller/hypervisor/`)** – Adds a lightweight hook so each hypervisor can declare the devices to probe, the preferred libvirt `virt-type`, and optional feature discovery (such as Hyper-V enlightenments for KVM on amd64).
+- **Admission webhooks (`pkg/virt-api/webhooks/validating-webhook/admitters/hypervisor/`)** – Validation uses the capability registry to automatically reject VMI configurations with unsupported features, generating rich error messages with documentation links. This replaces scattered architecture-specific validation with centralized capability queries.
+- **Node labeller (`pkg/virt-handler/node-labeller/hypervisor/`)** – Adds a lightweight hook so each hypervisor can declare the devices to probe, the preferred libvirt `virt-type`, and optional feature discovery (such as Hyper-V enlightenments for KVM on amd64). Can also expose capability labels on nodes for scheduling purposes.
 
 This split preserves the “implement once, reuse everywhere” story without routing everything through a monolithic interface. New hypervisors can land incrementally—start with defaults and webhooks, add converter support, then extend node labelling—while keeping the contract for each area explicit and testable.
 
@@ -89,6 +91,47 @@ spec:
 - `virt-controller` reads the configured hypervisor from `ClusterConfig` when generating launcher manifests and threads that ID through the `ConverterContext` so downstream components can act consistently.
 - Each package's registry uses the configured name to locate its implementation, avoiding a monolithic factory while keeping selection logic consistent.
 
+### Capability Registry Model
+
+The capability registry provides a declarative, structured way to express feature support:
+
+```go
+// Core types in pkg/capabilities/types.go
+type CapabilityKey string  // e.g., "graphics.vga", "firmware.secureboot.uefi"
+type SupportLevel int      // Supported, Unsupported, Experimental, Deprecated
+
+type Capability struct {
+    Level       SupportLevel
+    Message     string   // User-facing explanation
+    Since       string   // Version when support added
+    DocLink     string   // Link to documentation
+    GatedBy     string   // Optional: feature gate name
+}
+
+type CapabilitySet map[CapabilityKey]Capability
+```
+
+Each hypervisor+architecture combination declares its capabilities:
+
+```go
+// In pkg/capabilities/hypervisor/kvm/arm64.go
+func init() {
+    capabilities.Register("kvm", "arm64", CapabilitySet{
+        CapGraphicsVGA: {
+            Level: Unsupported,
+            Message: "VGA graphics not supported on ARM64 architecture",
+            DocLink: "https://kubevirt.io/user-guide/arm64-limitations",
+        },
+        CapGraphicsVirtIO: {
+            Level: Supported,
+            Message: "VirtIO graphics fully supported on KVM/arm64",
+            Since: "v0.30.0",
+        },
+        // ... more capabilities
+    })
+}
+```
+
 ### Integration with Defaults, Runtime, and Converter
 
 1. `virt-controller` and `virt-handler` read the configured hypervisor from `ClusterConfig`, add that ID to the serialized `ConverterContext` they already ship alongside the launcher pod, and virt-launcher folds it into its `DomainContext` right before domain generation.
@@ -107,7 +150,10 @@ spec:
 
 ### Hypervisor-Specific Defaults
 
-The defaults system is refactored to support multi-axis overrides (hypervisor, architecture, combined) without expanding large `switch` statements.
+- `pkg/capabilities/hypervisor/` hosts capability declarations organized by hypervisor and architecture (e.g., `kvm/amd64.go`, `kvm/arm64.go`, `hyperv-layered/amd64.go`). Each file declares which features are supported, unsupported, or experimental for that specific combination.
+- `pkg/defaults/ is refactored to support multi-axis overrides (hypervisor, architecture, combined) without expanding large `switch` statements.
+- `pkg/hypervisor/runtime/` introduces a sibling registry for `HypervisorRuntime` implementations. `virt-controller` consults it to call `AdjustResources` and `GetMemoryOverhead`, while virt-handler and virt-launcher reuse the same implementation for memlock sizing and `HandleHousekeeping`.
+- `pkg/virt-api/webhooks/validating-webhook/admitters/` uses the capability registry for automatic validation. The `VMIFeatureMapper` in `pkg/capabilities/vmi/mapper.go` extracts required capabilities from a VMI spec and queries the registry. This eliminates scattered architecture-specific validation files in favor of centralized capability queries.
 
 Precedence (least → most specific):
 1. Base defaults (generic cluster configuration driven)
@@ -209,7 +255,13 @@ Key points:
 ### Validation & Mutation Webhooks
 
 - The mutating webhook shares the same resolution flow and invokes `MutateVMI` early in the admission chain, giving providers a chance to normalize the spec (for example, seeding Hyper-V Layered feature blocks or toggling defaults) before Kubernetes persists the object.
-- Hypervisors can use `Validate` to enforce requirements. The validating webhooks inside `virt-api` read the configured hypervisor from `ClusterConfig`, matching the value embedded by `virt-controller`, so admission stays consistent with reconciliation.
+- The validating webhooks use the capability registry for automatic, consistent validation:
+  1. `VMIFeatureMapper` analyzes the VMI spec to extract required capabilities (e.g., if `video.type: vga`, requires `graphics.vga` capability)
+  2. Registry queries check if each capability is supported on the target hypervisor+architecture
+  3. Unsupported features generate rich error messages with explanations and documentation links
+  4. Unknown features log warnings but pass through (progressive enhancement during migration)
+- This approach replaces scattered validation logic (like `pkg/virt-api/webhooks/arm64.go`, `s390x.go`) with centralized capability queries, ensuring consistent validation behavior across all hypervisors.
+- The validating webhooks inside `virt-api` read the configured hypervisor from `ClusterConfig`, matching the value embedded by `virt-controller`, so admission stays consistent with reconciliation.
 - In tandem, these hooks enable opinionated defaults for each hypervisor while still rejecting incompatible specs, delivering flexibility without sacrificing guardrails.
 
 ### Observability Hooks
@@ -270,7 +322,7 @@ With this configuration in place, every VMI reconciled by the control plane inhe
    }
    ```
 
-2. **Runtime** – Add `pkg/hypervisor/runtime/sample.go` implementing the `HypervisorRuntime` interface so controllers, handlers, and virt-launcher share runtime hooks.
+1. **Runtime** – Add `pkg/hypervisor/runtime/sample.go` implementing the `HypervisorRuntime` interface so controllers, handlers, and virt-launcher share runtime hooks.
 
    ```go
    type sampleRuntime struct{}
@@ -294,7 +346,7 @@ With this configuration in place, every VMI reconciled by the control plane inhe
    }
    ```
 
-3. **Converter** – Add `pkg/virt-launcher/virtwrap/converter/hypervisor/sample.go` implementing the `HypervisorConverter` interface (overriding only the methods that differ from the base helper).
+1. **Converter** – Add `pkg/virt-launcher/virtwrap/converter/hypervisor/sample.go` implementing the `HypervisorConverter` interface (overriding only the methods that differ from the base helper).
 
    ```go
    type sampleConverter struct {
@@ -316,9 +368,9 @@ With this configuration in place, every VMI reconciled by the control plane inhe
    }
    ```
 
-4. **Admission** – Create `pkg/virt-api/webhooks/validating-webhook/admitters/hypervisor/sample.go` that exports `MutateVMI` and `Validate` functions and register them in the webhook registry.
+1. **Admission** – Create `pkg/virt-api/webhooks/validating-webhook/admitters/hypervisor/sample.go` that exports `MutateVMI` and `Validate` functions and register them in the webhook registry.
 
-4. **Node labeller (optional for MVP)** – Provide `pkg/virt-handler/node-labeller/hypervisor/sample.go` declaring the devices and libvirt `virt-type` to probe. If the hypervisor relies on architecture-specific features, add the corresponding helper hooks.
+1. **Node labeller (optional for MVP)** – Provide `pkg/virt-handler/node-labeller/hypervisor/sample.go` declaring the devices and libvirt `virt-type` to probe. If the hypervisor relies on architecture-specific features, add the corresponding helper hooks.
 
    ```go
    type sampleLabeller struct{}
@@ -335,6 +387,36 @@ With this configuration in place, every VMI reconciled by the control plane inhe
 
    func init() {
      RegisterHypervisorLabeller("sample", sampleLabeller{})
+   }
+   ```
+
+1. **Capabilities** – Declare feature support for each architecture in `pkg/capabilities/hypervisor/sample/`:
+
+   ```go
+   // pkg/capabilities/hypervisor/sample/amd64.go
+   func init() {
+       capabilities.Register("sample", "amd64", CapabilitySet{
+           CapGraphicsVirtIO: {
+               Level: Supported,
+               Message: "VirtIO graphics supported on sample/amd64",
+               Since: "v1.0.0",
+           },
+           CapGraphicsVGA: {
+               Level: Unsupported,
+               Message: "VGA graphics not supported on sample hypervisor",
+               DocLink: "https://example.com/sample/graphics",
+           },
+           CapSecureBootUEFI: {
+               Level: Experimental,
+               Message: "UEFI Secure Boot experimental on sample",
+               GatedBy: "SampleSecureBoot",
+           },
+           CapCPUHotplug: {
+               Level: Unsupported,
+               Message: "CPU hotplug not yet implemented for sample",
+           },
+           // Declare all relevant capabilities...
+       })
    }
    ```
 
@@ -363,8 +445,38 @@ Full abstraction with—multi-device descriptors, richer domain defaults, hyperv
 ## Functional Testing Approach
 
 - Unit tests for each hypervisor implementation verifying domain defaults and mutators.
+- Unit tests for capability registry ensuring correct capability queries and feature extraction.
 - Integration tests covering virt-controller manifest rendering and device manager plugin registration with other hypervisors enabled.
+- Integration tests verifying admission webhooks reject unsupported feature combinations with appropriate error messages.
 - End-to-end lanes that launch VMIs under at least two hypervisors (e.g., KVM plus a stub hypervisor) to confirm scheduling and domain generation.
+- Test filtering verification: Ensure tests with capability decorators run only on compatible hypervisor+architecture combinations.
+
+### Test Filtering Integration
+
+The capability registry enables automatic test filtering so tests only run on compatible infrastructure:
+
+```go
+// tests/decorators/capabilities.go
+var (
+    RequiresVGAGraphics    = decorators.RequiresCapability(capabilities.CapGraphicsVGA)
+    RequiresCPUHotplug     = decorators.RequiresCapability(capabilities.CapCPUHotplug)
+    RequiresSecureBoot     = decorators.RequiresCapability(capabilities.CapSecureBootUEFI)
+)
+
+// Test automatically skips if capability unsupported
+It("should support VGA graphics", RequiresVGAGraphics, func() {
+    vmi := libvmifact.NewCirros()
+    vmi.Spec.Domain.Devices.Video = &v1.Video{Type: "vga"}
+    // Test runs only on hypervisor+arch combos that support VGA
+})
+```
+
+The test framework generates label filters from the capability registry:
+- On KVM/amd64: VGA tests run
+- On KVM/arm64: VGA tests automatically skip (VGA unsupported)
+- On hyperv-layered: VGA tests automatically skip
+
+This eliminates scattered skip logic and ensures tests run only where they should.
 
 ## Implementation History
 
@@ -377,12 +489,18 @@ Full abstraction with—multi-device descriptors, richer domain defaults, hyperv
 - Feature gate covers configurable hypervisor
 - Cluster-wide hypervisor configuration implemented and consumed by defaults, converter, and webhooks.
 - Basic functional tests for alternative hypervisor scheduling and domain generation.
+- Capability registry implemented with KVM capabilities for amd64, arm64, and s390x.
+- Validation webhooks use capability registry to reject unsupported configurations.
+- Test filtering framework using capability decorators.
 
 ### Beta
 
 - Monitoring and observability hooks consumed by community dashboards.
 - Upgrade/rollback testing executed in CI.
+- Capability-based test filtering integrated into CI pipelines.
 
 ### GA
 
 - Documentation reflects hypervisor lifecycle and contributor workflow.
+- All architecture-specific validation code replaced with capability queries.
+- Capability registry covers all major features (graphics, firmware, CPU, networking, storage).

--- a/veps/sig-compute/hypervisor-abstraction.md
+++ b/veps/sig-compute/hypervisor-abstraction.md
@@ -131,68 +131,68 @@ Hypervisor+architecture combinations register their support using a builder patt
 
 ```go
 // pkg/capabilities/registry.go - Matrix registration with builder pattern
-type CapabilityMatrix struct {
+type Capabilities struct {
     matrix map[string]map[CapabilityKey]Capability // "hypervisor/arch" or "hypervisor" -> capabilities
 }
 
-type CapabilityBuilder struct {
-    matrix      *CapabilityMatrix
+type CapabilitiesBuilder struct {
+    matrix      *Capabilities
     platformKey string  // Composite key: "hypervisor/arch" or "hypervisor"
 }
 
-type CapabilityEntryBuilder struct {
-  builder *CapabilityBuilder
+type CapabilityBuilder struct {
+  builder *CapabilitiesBuilder
   cap     CapabilityKey
 }
 
-func Register(hypervisor, arch string) *CapabilityBuilder {
+func Register(hypervisor, arch string) *CapabilitiesBuilder {
     // Returns builder for registering capabilities
 }
 
 // Fluent methods for registering multiple capabilities at once
-func (b *CapabilityBuilder) Support(caps ...CapabilityKey) *CapabilityBuilder {
+func (b *CapabilitiesBuilder) Support(caps ...CapabilityKey) *CapabilitiesBuilder {
     // Mark capabilities as supported
 }
 
-func (b *CapabilityBuilder) Experimental(cap CapabilityKey, gate string) *CapabilityBuilder {
+func (b *CapabilitiesBuilder) Experimental(cap CapabilityKey, gate string) *CapabilitiesBuilder {
     // Mark capability as experimental with feature gate
 }
 
-func (b *CapabilityBuilder) Unsupported(caps ...CapabilityKey) *CapabilityBuilder {
+func (b *CapabilitiesBuilder) Unsupported(caps ...CapabilityKey) *CapabilitiesBuilder {
     // Explicitly mark as unsupported (for clarity/documentation)
 }
 
 // When richer metadata would otherwise repeat the capability key, `Cap(...)` returns a
 // capability-specific builder that keeps the fluent chain focused on a single key.
-func (b *CapabilityBuilder) Cap(cap CapabilityKey) *CapabilityEntryBuilder {
+func (b *CapabilitiesBuilder) Cap(cap CapabilityKey) *CapabilityBuilder {
   // Start capability-specific fluent builder to avoid repeating the key
 }
 
-func (e *CapabilityEntryBuilder) Support() *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) Support() *CapabilityBuilder {
   // Mark capability as supported and continue chaining metadata helpers
 }
 
-func (e *CapabilityEntryBuilder) Experimental(gate string) *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) Experimental(gate string) *CapabilityBuilder {
   // Mark capability as experimental with feature gate and continue chaining
 }
 
-func (e *CapabilityEntryBuilder) Unsupported() *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) Unsupported() *CapabilityBuilder {
   // Explicitly mark capability as unsupported and continue chaining metadata helpers
 }
 
-func (e *CapabilityEntryBuilder) WithMessage(msg string) *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) WithMessage(msg string) *CapabilityBuilder {
   // Attach custom message while staying on the capability-specific builder
 }
 
-func (e *CapabilityEntryBuilder) WithDocLink(link string) *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) WithDocLink(link string) *CapabilityBuilder {
   // Attach documentation link without repeating the capability key
 }
 
-func (e *CapabilityEntryBuilder) WithSince(version string) *CapabilityEntryBuilder {
+func (e *CapabilityBuilder) WithSince(version string) *CapabilityBuilder {
   // Record the release where support landed without repeating the key
 }
 
-func (e *CapabilityEntryBuilder) Done() *CapabilityBuilder {
+func (e *CapabilityBuilder) Done() *CapabilitiesBuilder {
   // Return to the parent builder after finishing metadata customization
 }
 

--- a/veps/sig-compute/hypervisor-abstraction.md
+++ b/veps/sig-compute/hypervisor-abstraction.md
@@ -107,17 +107,15 @@ type Capability struct {
     DocLink     string   // Link to documentation
     GatedBy     string   // Optional: feature gate name
 }
-
-type CapabilityInfo struct {
-    Description string   // Capability description
-    DocLink     string   // Default documentation link
-}
 ```
 
-All capabilities are defined once in a central registry:
+All capabilities are defined once as typed constants:
 
 ```go
 // pkg/capabilities/definitions.go - Define ALL capabilities once
+type CapabilityKey string
+
+// Capability constants - each represents a feature that can be supported/unsupported by hypervisors
 const (
     CapGraphicsVGA       CapabilityKey = "graphics.vga"
     CapGraphicsVirtIO    CapabilityKey = "graphics.virtio"
@@ -125,23 +123,9 @@ const (
     CapCPUHotplug        CapabilityKey = "cpu.hotplug"
     // ... all capabilities declared as constants
 )
-
-var CapabilityDefs = map[CapabilityKey]CapabilityInfo{
-    CapGraphicsVGA: {
-        Description: "VGA graphics support",
-        DocLink:     "https://kubevirt.io/user-guide/graphics#vga",
-    },
-    CapGraphicsVirtIO: {
-        Description: "VirtIO GPU support",
-        DocLink:     "https://kubevirt.io/user-guide/graphics#virtio",
-    },
-    CapSecureBootUEFI: {
-        Description: "UEFI Secure Boot support",
-        DocLink:     "https://kubevirt.io/user-guide/firmware#secureboot",
-    },
-    // ... metadata for all capabilities
-}
 ```
+
+Capabilities are fully defined when hypervisors register their support via the builder pattern. The `Capability` struct populated by the builder contains all necessary metadata (level, message, since, docLink, gatedBy), so no separate capability definition registry is needed.
 
 Hypervisor+architecture combinations register their support using a builder pattern with inheritance:
 
@@ -152,14 +136,20 @@ type CapabilityMatrix struct {
 }
 
 type CapabilityBuilder struct {
-    matrix *CapabilityMatrix
-    key    string
+    matrix      *CapabilityMatrix
+    platformKey string  // Composite key: "hypervisor/arch" or "hypervisor"
+}
+
+type CapabilityEntryBuilder struct {
+  builder *CapabilityBuilder
+  cap     CapabilityKey
 }
 
 func Register(hypervisor, arch string) *CapabilityBuilder {
     // Returns builder for registering capabilities
 }
 
+// Fluent methods for registering multiple capabilities at once
 func (b *CapabilityBuilder) Support(caps ...CapabilityKey) *CapabilityBuilder {
     // Mark capabilities as supported
 }
@@ -172,28 +162,68 @@ func (b *CapabilityBuilder) Unsupported(caps ...CapabilityKey) *CapabilityBuilde
     // Explicitly mark as unsupported (for clarity/documentation)
 }
 
-func (b *CapabilityBuilder) WithMessage(cap CapabilityKey, msg string) *CapabilityBuilder {
-    // Customize message for specific capability
+// When richer metadata would otherwise repeat the capability key, `Cap(...)` returns a
+// capability-specific builder that keeps the fluent chain focused on a single key.
+func (b *CapabilityBuilder) Cap(cap CapabilityKey) *CapabilityEntryBuilder {
+  // Start capability-specific fluent builder to avoid repeating the key
+}
+
+func (e *CapabilityEntryBuilder) Support() *CapabilityEntryBuilder {
+  // Mark capability as supported and continue chaining metadata helpers
+}
+
+func (e *CapabilityEntryBuilder) Experimental(gate string) *CapabilityEntryBuilder {
+  // Mark capability as experimental with feature gate and continue chaining
+}
+
+func (e *CapabilityEntryBuilder) Unsupported() *CapabilityEntryBuilder {
+  // Explicitly mark capability as unsupported and continue chaining metadata helpers
+}
+
+func (e *CapabilityEntryBuilder) WithMessage(msg string) *CapabilityEntryBuilder {
+  // Attach custom message while staying on the capability-specific builder
+}
+
+func (e *CapabilityEntryBuilder) WithDocLink(link string) *CapabilityEntryBuilder {
+  // Attach documentation link without repeating the capability key
+}
+
+func (e *CapabilityEntryBuilder) WithSince(version string) *CapabilityEntryBuilder {
+  // Record the release where support landed without repeating the key
+}
+
+func (e *CapabilityEntryBuilder) Done() *CapabilityBuilder {
+  // Return to the parent builder after finishing metadata customization
 }
 
 // Usage in init() - hypervisor implementations register support:
 func init() {
     // Register base KVM support (applies to all KVM archs unless overridden)
     Register("kvm", "").  // empty arch = hypervisor-wide default
-        Support(CapGraphicsVirtIO, CapSecureBootUEFI).
-        Experimental(CapCPUHotplug, "CPUHotplug")
+      Supprt(CapSecureBootUEFI).
+      Experimental(CapCPUHotplug).
+      Cap(CapGraphicsVirtIO).
+        Support().
+        WithDocLink("https://kubevirt.io/user-guide/graphics#virtio").
+        WithSince("v0.31.0").
+        Done()
     
     // Architecture-specific overrides for KVM
     Register("kvm", "amd64").
-        Support(CapGraphicsVGA).  // VGA only on amd64/s390x
-        WithMessage(CapGraphicsVGA, "VGA graphics fully supported on KVM/amd64")
+      Cap(CapGraphicsVGA).  // VGA only on amd64/s390x
+        Support().
+        WithMessage("VGA graphics fully supported on KVM/amd64").
+        WithDocLink("https://kubevirt.io/user-guide/graphics#vga").
+        Done()
     
     Register("kvm", "arm64").
-        Unsupported(CapGraphicsVGA).
-        WithMessage(CapGraphicsVGA, "VGA graphics not supported on ARM64 architecture")
+      Cap(CapGraphicsVGA).
+        Unsupported().
+        WithMessage("VGA graphics not supported on ARM64 architecture").
+        Done()
     
     Register("kvm", "s390x").
-        Support(CapGraphicsVGA)
+      Support(CapGraphicsVGA)
 }
 ```
 
@@ -203,12 +233,12 @@ The registry resolves capabilities using a layered fallback strategy:
 // Query with automatic fallback: hypervisor/arch -> hypervisor -> base
 func Get(hypervisor, arch string, cap CapabilityKey) Capability {
     // Try exact match: kvm/amd64
-    if c, ok := lookup(hypervisor+"/{arch}", cap); ok { return c }
+  if c, ok := lookup(hypervisor+"/"+arch, cap); ok { return c }
     
     // Try hypervisor-wide: kvm
     if c, ok := lookup(hypervisor, cap); ok { return c }
     
-    // Default: unsupported with generic message
+    // Default: unsupported with a generic "<cap> unsupported" message
     return defaultUnsupported(cap)
 }
 ```
@@ -216,7 +246,7 @@ func Get(hypervisor, arch string, cap CapabilityKey) Capability {
 Resolution precedence (most specific wins):
 1. **Hypervisor+Architecture** (e.g., `kvm/amd64`) - most specific
 2. **Hypervisor-wide** (e.g., `kvm`) - applies to all architectures unless overridden
-3. **Default** - unsupported with generic message from `CapabilityDefs`
+3. **Default** - unsupported with a generic message derived from the capability key (e.g. "graphics.vga unsupported")
 
 ### Integration with Defaults, Runtime, and Converter
 
@@ -236,7 +266,7 @@ Resolution precedence (most specific wins):
 
 ### Hypervisor-Specific Defaults
 
-- `pkg/capabilities/` hosts the centralized capability registry. `definitions.go` contains all capability constants and metadata, while `registry.go` provides the builder pattern for registration. `init.go` or hypervisor-specific registration files (e.g., `kvm.go`, `hyperv.go`) use the builder to declare support for each hypervisor and architecture combination.
+- `pkg/capabilities/` hosts the centralized capability registry. `definitions.go` contains the capability constants, while `registry.go` provides the builder pattern for registering support plus metadata. `init.go` or hypervisor-specific registration files (e.g., `kvm.go`, `hyperv.go`) use the builder to declare support for each hypervisor and architecture combination.
 - `pkg/defaults/ is refactored to support multi-axis overrides (hypervisor, architecture, combined) without expanding large `switch` statements.
 - `pkg/hypervisor/runtime/` introduces a sibling registry for `HypervisorRuntime` implementations. `virt-controller` consults it to call `AdjustResources` and `GetMemoryOverhead`, while virt-handler and virt-launcher reuse the same implementation for memlock sizing and `HandleHousekeeping`.
 - `pkg/virt-api/webhooks/validating-webhook/admitters/` uses the capability registry for automatic validation. The `VMIFeatureMapper` in `pkg/capabilities/vmi/mapper.go` extracts required capabilities from a VMI spec and queries the registry. This eliminates scattered architecture-specific validation files in favor of centralized capability queries.

--- a/veps/sig-compute/hypervisor-abstraction.md
+++ b/veps/sig-compute/hypervisor-abstraction.md
@@ -66,7 +66,7 @@ Cluster configuration (`spec.configuration.hypervisorConfiguration.name`) declar
    ```
    Only zero-value fields are set at each layer; `FinalizeVMI` handles derived/status data (CPU topology snapshot, memory status, hotplug sizing, feature dependency resolution). Existing public functions delegate to the resolved provider for backwards compatibility.
 
-- **Capability registry (`pkg/capabilities/`)** – Provides a centralized, declarative model for expressing which features are supported, unsupported, or experimental on each hypervisor+architecture combination. The registry enables automatic validation, test filtering, and clear error messages without duplicating logic across components. Each hypervisor declares its capabilities once (e.g., `pkg/capabilities/hypervisor/kvm/amd64.go`) and all validation/testing consumes these declarations.
+- **Capability registry (`pkg/capabilities/`)** – Provides a centralized, declarative matrix for expressing which features are supported, unsupported, or experimental on each hypervisor+architecture combination. All capabilities are defined once in `pkg/capabilities/definitions.go`, and hypervisor implementations register their support using a builder pattern with inheritance. The registry enables automatic validation, test filtering, and clear error messages without duplicating logic across components. Resolution follows a layered fallback strategy (hypervisor/arch → hypervisor → default) similar to the defaults provider pattern.
 - **Runtime interface (`pkg/hypervisor/runtime/`)** – Provides a shared `HypervisorRuntime` contract for runtime-specific behavior such as `AdjustResources`, `HandleHousekeeping`, and `GetMemoryOverhead`. Each implementation registers under the same hypervisor key so `virt-controller`, `virt-handler`, and virt-launcher can resolve the correct runtime hooks.
 - **Converter library (`pkg/virt-launcher/virtwrap/converter/hypervisor/`)** – Implements the new `HypervisorConverter` interface described below. Each hypervisor file focuses on XML/domain differences while `base.go` holds the shared helpers. The converter selects the correct implementation via a local registry keyed by hypervisor name.
 - **Admission webhooks (`pkg/virt-api/webhooks/validating-webhook/admitters/hypervisor/`)** – Validation uses the capability registry to automatically reject VMI configurations with unsupported features, generating rich error messages with documentation links. This replaces scattered architecture-specific validation with centralized capability queries.
@@ -93,7 +93,7 @@ spec:
 
 ### Capability Registry Model
 
-The capability registry provides a declarative, structured way to express feature support:
+The capability registry provides a centralized, declarative matrix for expressing feature support. Instead of requiring separate files per hypervisor+architecture combination, all capabilities are defined once and hypervisor implementations register their support using a builder pattern:
 
 ```go
 // Core types in pkg/capabilities/types.go
@@ -108,29 +108,115 @@ type Capability struct {
     GatedBy     string   // Optional: feature gate name
 }
 
-type CapabilitySet map[CapabilityKey]Capability
-```
-
-Each hypervisor+architecture combination declares its capabilities:
-
-```go
-// In pkg/capabilities/hypervisor/kvm/arm64.go
-func init() {
-    capabilities.Register("kvm", "arm64", CapabilitySet{
-        CapGraphicsVGA: {
-            Level: Unsupported,
-            Message: "VGA graphics not supported on ARM64 architecture",
-            DocLink: "https://kubevirt.io/user-guide/arm64-limitations",
-        },
-        CapGraphicsVirtIO: {
-            Level: Supported,
-            Message: "VirtIO graphics fully supported on KVM/arm64",
-            Since: "v0.30.0",
-        },
-        // ... more capabilities
-    })
+type CapabilityInfo struct {
+    Description string   // Capability description
+    DocLink     string   // Default documentation link
 }
 ```
+
+All capabilities are defined once in a central registry:
+
+```go
+// pkg/capabilities/definitions.go - Define ALL capabilities once
+const (
+    CapGraphicsVGA       CapabilityKey = "graphics.vga"
+    CapGraphicsVirtIO    CapabilityKey = "graphics.virtio"
+    CapSecureBootUEFI    CapabilityKey = "firmware.secureboot.uefi"
+    CapCPUHotplug        CapabilityKey = "cpu.hotplug"
+    // ... all capabilities declared as constants
+)
+
+var CapabilityDefs = map[CapabilityKey]CapabilityInfo{
+    CapGraphicsVGA: {
+        Description: "VGA graphics support",
+        DocLink:     "https://kubevirt.io/user-guide/graphics#vga",
+    },
+    CapGraphicsVirtIO: {
+        Description: "VirtIO GPU support",
+        DocLink:     "https://kubevirt.io/user-guide/graphics#virtio",
+    },
+    CapSecureBootUEFI: {
+        Description: "UEFI Secure Boot support",
+        DocLink:     "https://kubevirt.io/user-guide/firmware#secureboot",
+    },
+    // ... metadata for all capabilities
+}
+```
+
+Hypervisor+architecture combinations register their support using a builder pattern with inheritance:
+
+```go
+// pkg/capabilities/registry.go - Matrix registration with builder pattern
+type CapabilityMatrix struct {
+    matrix map[string]map[CapabilityKey]Capability // "hypervisor/arch" or "hypervisor" -> capabilities
+}
+
+type CapabilityBuilder struct {
+    matrix *CapabilityMatrix
+    key    string
+}
+
+func Register(hypervisor, arch string) *CapabilityBuilder {
+    // Returns builder for registering capabilities
+}
+
+func (b *CapabilityBuilder) Support(caps ...CapabilityKey) *CapabilityBuilder {
+    // Mark capabilities as supported
+}
+
+func (b *CapabilityBuilder) Experimental(cap CapabilityKey, gate string) *CapabilityBuilder {
+    // Mark capability as experimental with feature gate
+}
+
+func (b *CapabilityBuilder) Unsupported(caps ...CapabilityKey) *CapabilityBuilder {
+    // Explicitly mark as unsupported (for clarity/documentation)
+}
+
+func (b *CapabilityBuilder) WithMessage(cap CapabilityKey, msg string) *CapabilityBuilder {
+    // Customize message for specific capability
+}
+
+// Usage in init() - hypervisor implementations register support:
+func init() {
+    // Register base KVM support (applies to all KVM archs unless overridden)
+    Register("kvm", "").  // empty arch = hypervisor-wide default
+        Support(CapGraphicsVirtIO, CapSecureBootUEFI).
+        Experimental(CapCPUHotplug, "CPUHotplug")
+    
+    // Architecture-specific overrides for KVM
+    Register("kvm", "amd64").
+        Support(CapGraphicsVGA).  // VGA only on amd64/s390x
+        WithMessage(CapGraphicsVGA, "VGA graphics fully supported on KVM/amd64")
+    
+    Register("kvm", "arm64").
+        Unsupported(CapGraphicsVGA).
+        WithMessage(CapGraphicsVGA, "VGA graphics not supported on ARM64 architecture")
+    
+    Register("kvm", "s390x").
+        Support(CapGraphicsVGA)
+}
+```
+
+The registry resolves capabilities using a layered fallback strategy:
+
+```go
+// Query with automatic fallback: hypervisor/arch -> hypervisor -> base
+func Get(hypervisor, arch string, cap CapabilityKey) Capability {
+    // Try exact match: kvm/amd64
+    if c, ok := lookup(hypervisor+"/{arch}", cap); ok { return c }
+    
+    // Try hypervisor-wide: kvm
+    if c, ok := lookup(hypervisor, cap); ok { return c }
+    
+    // Default: unsupported with generic message
+    return defaultUnsupported(cap)
+}
+```
+
+Resolution precedence (most specific wins):
+1. **Hypervisor+Architecture** (e.g., `kvm/amd64`) - most specific
+2. **Hypervisor-wide** (e.g., `kvm`) - applies to all architectures unless overridden
+3. **Default** - unsupported with generic message from `CapabilityDefs`
 
 ### Integration with Defaults, Runtime, and Converter
 
@@ -150,7 +236,7 @@ func init() {
 
 ### Hypervisor-Specific Defaults
 
-- `pkg/capabilities/hypervisor/` hosts capability declarations organized by hypervisor and architecture (e.g., `kvm/amd64.go`, `kvm/arm64.go`, `hyperv-layered/amd64.go`). Each file declares which features are supported, unsupported, or experimental for that specific combination.
+- `pkg/capabilities/` hosts the centralized capability registry. `definitions.go` contains all capability constants and metadata, while `registry.go` provides the builder pattern for registration. `init.go` or hypervisor-specific registration files (e.g., `kvm.go`, `hyperv.go`) use the builder to declare support for each hypervisor and architecture combination.
 - `pkg/defaults/ is refactored to support multi-axis overrides (hypervisor, architecture, combined) without expanding large `switch` statements.
 - `pkg/hypervisor/runtime/` introduces a sibling registry for `HypervisorRuntime` implementations. `virt-controller` consults it to call `AdjustResources` and `GetMemoryOverhead`, while virt-handler and virt-launcher reuse the same implementation for memlock sizing and `HandleHousekeeping`.
 - `pkg/virt-api/webhooks/validating-webhook/admitters/` uses the capability registry for automatic validation. The `VMIFeatureMapper` in `pkg/capabilities/vmi/mapper.go` extracts required capabilities from a VMI spec and queries the registry. This eliminates scattered architecture-specific validation files in favor of centralized capability queries.
@@ -390,33 +476,24 @@ With this configuration in place, every VMI reconciled by the control plane inhe
    }
    ```
 
-1. **Capabilities** – Declare feature support for each architecture in `pkg/capabilities/hypervisor/sample/`:
+1. **Capabilities** – Register feature support using the centralized capability registry (typically in `pkg/capabilities/sample-hypervisor.go` or within the same init):
 
    ```go
-   // pkg/capabilities/hypervisor/sample/amd64.go
    func init() {
-       capabilities.Register("sample", "amd64", CapabilitySet{
-           CapGraphicsVirtIO: {
-               Level: Supported,
-               Message: "VirtIO graphics supported on sample/amd64",
-               Since: "v1.0.0",
-           },
-           CapGraphicsVGA: {
-               Level: Unsupported,
-               Message: "VGA graphics not supported on sample hypervisor",
-               DocLink: "https://example.com/sample/graphics",
-           },
-           CapSecureBootUEFI: {
-               Level: Experimental,
-               Message: "UEFI Secure Boot experimental on sample",
-               GatedBy: "SampleSecureBoot",
-           },
-           CapCPUHotplug: {
-               Level: Unsupported,
-               Message: "CPU hotplug not yet implemented for sample",
-           },
-           // Declare all relevant capabilities...
-       })
+       // Register hypervisor-wide support (all architectures)
+       capabilities.Register("sample-hypervisor", "").
+           Support(CapGraphicsVirtIO).
+           Unsupported(CapGraphicsVGA).
+           WithMessage(CapGraphicsVGA, "VGA graphics not supported on sample hypervisor").
+           WithMessage(CapGraphicsVirtIO, "VirtIO graphics supported on all sample architectures")
+       
+       // Architecture-specific overrides
+       capabilities.Register("sample-hypervisor", "amd64").
+           Experimental(CapSecureBootUEFI, "SampleSecureBoot").
+           WithMessage(CapSecureBootUEFI, "UEFI Secure Boot experimental on sample/amd64")
+       
+       // CPU hotplug unsupported everywhere (inherits from hypervisor-wide if not explicitly marked)
+       // No need to repeat unless you want custom messages per arch
    }
    ```
 


### PR DESCRIPTION
A couple key aspects/benefits to updates:

- All capabilities defined once in `definitions.go` with consistent naming and documentation
- Adding a new hypervisor requires only calling `Register()` with the hypervisor/arch combination
- New capabilities are added to `definitions.go` and immediately available for all hypervisors to reference
- Hypervisor-wide settings apply to all architectures, with architecture-specific overrides for divergence
- The registration code naturally shows what each hypervisor supports without navigating multiple files
